### PR TITLE
DIGEST-MD5 fixes and improvements

### DIFF
--- a/lib/net/sasl/digest_md5_authenticator.rb
+++ b/lib/net/sasl/digest_md5_authenticator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "digest/md5"
+require "securerandom"
 require "strscan"
 
 module Net
@@ -71,8 +72,7 @@ module Net
             nonce: sparams["nonce"],
             username: @username.dup,
             realm: sparams["realm"],
-            cnonce: Digest::MD5.hexdigest("%.15f:%.15f:%d" % [Time.now.to_f, rand,
-                                                              Process.pid.to_s,]),
+            cnonce: SecureRandom.hex(32),
             'digest-uri': @uri || +"imap/#{sparams["realm"]}",
             qop: +"auth",
             maxbuf: 65_535,

--- a/lib/net/sasl/digest_md5_authenticator.rb
+++ b/lib/net/sasl/digest_md5_authenticator.rb
@@ -34,9 +34,10 @@ module Net
       # incorrect, and authentication will fail."
       #
       # This should generally be instantiated via Net::SASL.authenticator.
-      def initialize(username, password, authzid = nil, **_options)
+      def initialize(username, password, authzid = nil, uri: nil, **_options)
         super
         @username, @password, @authzid = username, password, authzid
+        @uri = uri
         @nc, @stage = {}, STAGE_ONE
       end
 
@@ -72,7 +73,7 @@ module Net
             realm: sparams["realm"],
             cnonce: Digest::MD5.hexdigest("%.15f:%.15f:%d" % [Time.now.to_f, rand,
                                                               Process.pid.to_s,]),
-            'digest-uri': +"imap/#{sparams["realm"]}",
+            'digest-uri': @uri || +"imap/#{sparams["realm"]}",
             qop: +"auth",
             maxbuf: 65_535,
             nc: "%08d" % nc(sparams["nonce"]),

--- a/lib/net/sasl/digest_md5_authenticator.rb
+++ b/lib/net/sasl/digest_md5_authenticator.rb
@@ -68,18 +68,18 @@ module Net
 
           response = {
             nonce: sparams["nonce"],
-            username: @username,
+            username: @username.dup,
             realm: sparams["realm"],
             cnonce: Digest::MD5.hexdigest("%.15f:%.15f:%d" % [Time.now.to_f, rand,
                                                               Process.pid.to_s,]),
-            'digest-uri': "imap/#{sparams["realm"]}",
-            qop: "auth",
+            'digest-uri': +"imap/#{sparams["realm"]}",
+            qop: +"auth",
             maxbuf: 65_535,
             nc: "%08d" % nc(sparams["nonce"]),
             charset: sparams["charset"],
           }
 
-          response[:authzid] = @authzid unless @authzid.nil?
+          response[:authzid] = @authzid.dup unless @authzid.nil?
 
           # now, the real thing
           a0 = Digest::MD5.digest([ response.values_at(:username, :realm),

--- a/test/net/sasl_test.rb
+++ b/test/net/sasl_test.rb
@@ -27,4 +27,20 @@ class Net::SASLTest < Test::Unit::TestCase
     assert_raise(ArgumentError) { plain("u", "p", "bad\0authz") }
   end
 
+  test "DIGEST-MD5 authenticator" do
+    auth = Net::SASL.authenticator("DIGEST-MD5", "cid", "password", "zid")
+    assert_match(
+      #Regexp.new("nonce=\"OA6MG9tEQGm2hh\",username=\"cid\",realm=\"somerealm\"," \
+      #"cnonce=\"[^\"]+\"," \
+      #"digest-uri=\"imap/somerealm\",qop=\"auth\",maxbuf=65535,nc=00000001," \
+      #"charset=utf-8,authzid=\"zid\",response=
+		/\Anonce="OA6MG9tEQGm2hh",username="cid",realm="somerealm",
+         cnonce="[a-f0-9]+",digest-uri="imap\/somerealm",qop="auth",maxbuf=65535,
+         nc=00000001,charset=utf-8,authzid="zid",
+         response=[a-f0-9]+\Z/x,
+      auth.process(
+        "realm=\"somerealm\",nonce=\"OA6MG9tEQGm2hh\",qop=\"auth\"," \
+        "charset=utf-8,algorithm=md5-sess"))
+  end
+
 end


### PR DESCRIPTION
* Fix a crash due to frozen string literal (and add a test).
* Allow setting non-IMAP digest-uri
* Use SecureRandom for the cnonce