### PR TITLE
Add support for SCRAM-SHA-*

### DIFF
--- a/lib/net/sasl.rb
+++ b/lib/net/sasl.rb
@@ -7,6 +7,7 @@ require_relative "sasl/cram_md5_authenticator"
 require_relative "sasl/digest_md5_authenticator"
 require_relative "sasl/login_authenticator"
 require_relative "sasl/plain_authenticator"
+require_relative "sasl/scram_authenticator"
 
 module Net
 
@@ -57,10 +58,15 @@ module Net
     # The default global registry used by Net::SASL.authenticator
     DEFAULT_REGISTRY = Registry.new
 
-    add_authenticator "PLAIN",      PlainAuthenticator
-    add_authenticator "LOGIN",      LoginAuthenticator
-    add_authenticator "DIGEST-MD5", DigestMD5Authenticator
-    add_authenticator "CRAM-MD5",   CramMD5Authenticator
+    add_authenticator "PLAIN",         PlainAuthenticator
+    add_authenticator "LOGIN",         LoginAuthenticator
+    add_authenticator "DIGEST-MD5",    DigestMD5Authenticator
+    add_authenticator "CRAM-MD5",      CramMD5Authenticator
+    add_authenticator "SCRAM-SHA-1",   ScramAuthenticator.for("SHA1")
+    add_authenticator "SCRAM-SHA-224", ScramAuthenticator.for("SHA224")
+    add_authenticator "SCRAM-SHA-256", ScramAuthenticator.for("SHA256")
+    add_authenticator "SCRAM-SHA-384", ScramAuthenticator.for("SHA384")
+    add_authenticator "SCRAM-SHA-512", ScramAuthenticator.for("SHA512")
 
   end
 

--- a/lib/net/sasl/scram_authenticator.rb
+++ b/lib/net/sasl/scram_authenticator.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "idn"
+require "openssl"
+require "securerandom"
+
+module Net
+
+  module SASL
+
+    # Authenticator for the "`SCRAM`" family of SASL mechanism types specified
+    # in RFC5802(https://tools.ietf.org/html/rfc5802).
+    class ScramAuthenticator < Authenticator
+
+      def self.for(hash)
+        Class.new(ScramAuthenticator) do
+          define_method :initialize do |*args, **options|
+            super(*args, hash: hash, **options)
+          end
+        end
+      end
+
+      # Provide the +username+ and +password+ credentials.  An optional
+      # +authzid+ is defined as: "The "authorization ID" as per
+      # RFC2222[https://tools.ietf.org/html/rfc2222],
+      # encoded in UTF-8. optional. If present, and the
+      # authenticating user has sufficient privilege, and the server supports
+      # it, then after authentication the server will use this identity for
+      # making all accesses and access checks.  If the client specifies it, and
+      # the server does not support it, then the response-value will be
+      # incorrect, and authentication will fail."
+      #
+      # This should generally be instantiated via Net::SASL.authenticator.
+      def initialize(username, password, authzid = nil, hash:, **options)
+        super
+        @hash = OpenSSL::Digest.new(hash)
+        @cnonce = options[:cnonce] || SecureRandom.hex(32)
+        @done = false
+      end
+
+      def supports_initial_response?
+        true
+      end
+
+      def done?
+        @done
+      end
+
+      # responds to the server's challenges
+      def process(challenge)
+        return "n,#{'a=' + @authzid if @authzid},#{initial_message}" if challenge.nil?
+
+        sparams = challenge.split(/,/).each_with_object({}) do |pair, h|
+          k, v = pair.split(/=/)
+          h[k] = v
+        end
+
+        if @server_signature
+          @done = sparams["v"].unpack("m").first == @server_signature
+          return if @done
+
+          raise ChallengeParseError, "Bad server signature"
+        end
+
+        bare = "c=biws,r=#{sparams['r']}"
+        salted_password = OpenSSL::KDF.pbkdf2_hmac(
+          IDN::Stringprep.with_profile(@password.encode("utf-8"), "SASLprep"),
+          salt: sparams["s"].unpack("m").first,
+          iterations: sparams["i"].to_i,
+          length: @hash.digest_length,
+          hash: @hash
+        )
+        client_key = OpenSSL::HMAC.digest(@hash, salted_password, "Client Key")
+        stored_key = @hash.digest(client_key)
+        auth_message = "#{initial_message},#{challenge},#{bare}"
+        client_signature = OpenSSL::HMAC.digest(@hash, stored_key, auth_message)
+        client_proof = client_key.bytes.zip(client_signature.bytes).map { |x,y| (x ^ y).chr }.join
+        server_key = OpenSSL::HMAC.digest(@hash, salted_password, "Server Key")
+        @server_signature = OpenSSL::HMAC.digest(@hash, server_key, auth_message)
+        "#{bare},p=#{[client_proof].pack('m').chomp}"
+      end
+
+    protected
+
+      def initial_message
+        "n=#{@username},r=#{@cnonce}"
+      end
+
+    end
+  end
+end

--- a/net-sasl.gemspec
+++ b/net-sasl.gemspec
@@ -28,5 +28,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "digest"
+  spec.add_dependency "idn-ruby"
   spec.add_dependency "strscan"
 end

--- a/test/net/sasl_test.rb
+++ b/test/net/sasl_test.rb
@@ -27,4 +27,17 @@ class Net::SASLTest < Test::Unit::TestCase
     assert_raise(ArgumentError) { plain("u", "p", "bad\0authz") }
   end
 
+  test "SCRAM-SHA-1 authenticator" do
+    authenticator = Net::SASL.authenticator("SCRAM-SHA-1", "user", "pencil", "zid", cnonce: "fyko+d2lbbFgONRv9qkxdawL")
+    assert_equal "n,a=zid,n=user,r=fyko+d2lbbFgONRv9qkxdawL", authenticator.process(nil)
+    refute authenticator.done?
+    assert_equal(
+      "c=biws,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=v0X8v3Bz2T0CJGbJQyF0X+HI4Ts=",
+      authenticator.process("r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096")
+    )
+    refute authenticator.done?
+    assert authenticator.process("v=rmF9pqV8S7suAoZWja4dJRkFsKQ=").nil?
+    assert authenticator.done?
+  end
+
 end


### PR DESCRIPTION
No -PLUS yet, no support for channel binding.
Also supports SCRAM-* for any OpenSSL-supported digest function with just one
line of code in the future.